### PR TITLE
Fix self.find_by_name method to remove name parameter from execute

### DIFF
--- a/lib/interactive_record.rb
+++ b/lib/interactive_record.rb
@@ -48,9 +48,10 @@ class InteractiveRecord
     self.class.column_names.delete_if {|col| col == "id"}.join(", ")
   end
 
-def self.find_by_name(name)
-  sql = "SELECT * FROM #{self.table_name} WHERE name = '?'"
-  DB[:conn].execute(sql, name)
-end
+  def self.find_by_name(name)
+    sql = "SELECT * FROM #{self.table_name} WHERE name = '#{name}'"
+    DB[:conn].execute(sql)
+  end
+
 
 end


### PR DESCRIPTION
Matching conventions within this lesson, the name parameter needs to be interpolated within the SQL statement:

def self.find_by_name(name)
    sql = "SELECT * FROM #{self.table_name} WHERE name = '#{name}'"
    DB[:conn].execute(sql)
end

A sanitized version with the same results:
def self.find_by_name(name)
    DB[:conn].execute("SELECT * FROM table_name = ? WHERE name = ?", self.table_name, name)
end

NOTE: Tests do not pass on the solution branch. Needs review.